### PR TITLE
Keyboard shortcuts

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-chrome.commands.onCommand.addListener((command) => {
+chrome.commands.onCommand.addListener(() => {
   chrome.tabs.query({}, (tabs) => {
     const tabUrls = new Set();
     tabs.forEach((tab) => {

--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-chrome.action.onClicked.addListener(() => {
+chrome.commands.onCommand.addListener((command) => {
   chrome.tabs.query({}, (tabs) => {
     const tabUrls = new Set();
     tabs.forEach((tab) => {

--- a/manifest.json
+++ b/manifest.json
@@ -9,9 +9,9 @@
   "commands":{
     "close": {
       "suggested_key": {
-        "windows": "Ctrl+C",
-        "linux":"Ctrl+C",
-        "chromeos":"Ctrl+C",
+        "windows": "Alt+C",
+        "linux":"Alt+C",
+        "chromeos":"Alt+C",
         "mac": "MacCtrl+C"
       },
       "description":"Close duplicate tabs"

--- a/manifest.json
+++ b/manifest.json
@@ -11,12 +11,7 @@
       "description":"Close duplicate tabs"
     },
     "_execute_action":{
-      "suggested_key":{
-        "linux":"Alt+U",
-        "windows":"Alt+U",
-        "chromeos":"Alt+U",
-        "mac":"MacCtrl+U"
-      }
+      "suggested_key": "Alt+U"
     }
 
   },

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,20 @@
   "version": "1.0",
   "description": "A Chrome extension to close duplicate tabs.",
   "permissions": [
-    "tabs"
+    "tabs","scripting"
   ],
+  "commands":{
+    "close": {
+      "suggested_key": {
+        "windows": "Ctrl+C",
+        "linux":"Ctrl+C",
+        "chromeos":"Ctrl+C",
+        "mac": "MacCtrl+C"
+      },
+      "description":"Close duplicate tabs"
+
+    }
+  },
   "background": {
     "service_worker": "background.js"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "description": "A Chrome extension to close duplicate tabs.",
   "permissions": [
-    "tabs","scripting"
+    "tabs"
   ],
   "commands":{
     "close": {

--- a/manifest.json
+++ b/manifest.json
@@ -8,15 +8,17 @@
   ],
   "commands":{
     "close": {
-      "suggested_key": {
-        "windows": "Alt+C",
-        "linux":"Alt+C",
-        "chromeos":"Alt+C",
-        "mac": "MacCtrl+C"
-      },
       "description":"Close duplicate tabs"
-
+    },
+    "_execute_action":{
+      "suggested_key":{
+        "linux":"Alt+U",
+        "windows":"Alt+U",
+        "chromeos":"Alt+U",
+        "mac":"MacCtrl+U"
+      }
     }
+
   },
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
Adds a default keyboard shortcut to `_execute_action` to open the `popup.html` window without needing to click on the extension.  Adds a command to close all duplicate tabs directly. The `close` command has no default shortcut so that users need to opt in to having a shortcut that closes tabs without confirmation. Users who would want that behavior can set a shortcut in `chrome://extensions/shortcuts`